### PR TITLE
'Slider' is now exported as a type (index.d.ts)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -105,5 +105,5 @@ declare module '@miblanchard/react-native-slider' {
     value?: number | number[];
   }
 
-  export const Slider: ComponentClass<ISliderProps>;
+  export class Slider extends PureComponent<ISliderProps> {}
 }


### PR DESCRIPTION
Fixed TypeScript error when using Slider as a type (eg. for refs): 'Slider' refers to a value, but is being used as a type here.