### PR TITLE
Round to closes step instead of flooring

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -338,7 +338,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
                 Math.min(
                     maxValue,
                     minimumValue +
-                        Math.floor(
+                        Math.round(
                             (ratio * (maximumValue - minimumValue)) / step,
                         ) *
                             step,


### PR DESCRIPTION
Gives a more expected visual result when the number of steps in a slider is low.