### PR TITLE
Remove dep on track marker array size

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -199,8 +199,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
             const statePatch = {} as SliderState;
 
             if (
-                state.trackMarksValues &&
-                newTrackMarkValues.length !== state.trackMarksValues.length
+                state.trackMarksValues
             ) {
                 statePatch.trackMarksValues = updateValues({
                     values: state.trackMarksValues,


### PR DESCRIPTION
Ran into this while working on a slider. Can we remove the requirement for the track marker array size update call so that new marker values can be rerendered?