### PR TITLE
feat: add startFromZero

### DIFF
--- a/src/stories/Slider.tsx
+++ b/src/stories/Slider.tsx
@@ -90,6 +90,26 @@ const SliderContainer = (props: {
 const App = () => (
     <SafeAreaView>
         <ScrollView contentContainerStyle={styles.container}>
+            <SliderContainer caption="<Slider/> to test the start from zero - symmetric">
+                <Slider
+                    value={DEFAULT_VALUE}
+                    minimumValue={-1}
+                    maximumValue={1}
+                    step={0.01}
+                    startFromZero
+                    trackClickable={true}
+                />
+            </SliderContainer>
+            <SliderContainer caption="<Slider/> to test the start from zero - asymmetric">
+                <Slider
+                    value={DEFAULT_VALUE}
+                    minimumValue={-0.4}
+                    maximumValue={1}
+                    step={0.01}
+                    startFromZero
+                    trackClickable={true}
+                />
+            </SliderContainer>
             <SliderContainer caption="<Slider/> to test click rounding">
                 <Slider
                     value={3}

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,11 @@ export type SliderProps = {
     trackMarks?: Array<number>;
     trackStyle?: ViewStyle;
     value?: Animated.Value | number | Array<number>;
+    /**
+     * Allows the start from the zero value. The minimum value track can be rendered in two directions from zero.
+     * Can be applied only with a single numeric value, negative minimum value, and positive maximum value.
+     */
+    startFromZero?: boolean;
     vertical?: boolean;
 };
 


### PR DESCRIPTION
Added an ability to have the start from the zero value. Can be useful for cases with negative minimum and positive maximum values.
Can be applied only with a single numeric value, negative minimum value, and positive maximum value.

* feat: add startFromZero

* feat: add an example of using to the storybook

* fix: border-radius cleanup at zero point

<img width="1187" alt="Screenshot 2022-05-05 at 13 26 22" src="https://user-images.githubusercontent.com/41872546/166905644-c9a5acce-fae1-4ad1-8c1c-6bdef91fb2cb.png">


