### PR TITLE
feat: Separate thumb components

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -831,7 +831,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
                             {renderThumbComponent
                                 ? Array.isArray(renderThumbComponent)
                                     ? renderThumbComponent[i]()
-                                    : renderThumbComponent
+                                    : renderThumbComponent()
                                 : this._renderThumbImage(i)}
                         </Animated.View>
                     ))}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -829,7 +829,9 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
                             ]}
                             onLayout={this._measureThumb}>
                             {renderThumbComponent
-                                ? renderThumbComponent()
+                                ? Array.isArray(renderThumbComponent)
+                                    ? renderThumbComponent[i]()
+                                    : renderThumbComponent
                                 : this._renderThumbImage(i)}
                         </Animated.View>
                     ))}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type Dimensions = {
 /**
  * Callback for slider change events. The second number value will be only if provided an array with two values in `value` prop
  */
-type SliderOnChangeCallback = (value: number | Array<number>) => void;
+export type SliderOnChangeCallback = (value: number | Array<number>) => void;
 
 export type SliderProps = {
     animateTransitions?: boolean;
@@ -36,7 +36,7 @@ export type SliderProps = {
         value: number,
         index: number,
     ) => React.ReactNode;
-    renderThumbComponent?: () => React.ReactNode;
+    renderThumbComponent?: () => React.ReactNode | Array<() => React.ReactNode>;
     renderTrackMarkComponent?: (index: number) => React.ReactNode;
     step?: number;
     thumbImage?: ImageSourcePropType;


### PR DESCRIPTION
This pr adds possibility to add separate component per thumb.
I needed it to achieve values under thumbs.

Btw. callback is now exported too.

Resolve: #362 
Resolve: #361

```
renderThumbComponent={[
  () => <SliderThumb value={value[0]} />,
  () => <SliderThumb value={value[1]} />,
]}
```

![IMG_2890](https://user-images.githubusercontent.com/14142246/188866022-0dffdac5-c5c3-4791-b726-0c5397ea142c.jpg)
