### PR TITLE
Fix touch offsets

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -256,6 +256,11 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
             ? nativeEvent.locationX - thumbSize.width
             : this._getThumbLeft(this._getCurrentValue(this._activeThumbIndex));
 
+        if (this.props.thumbTouchSize) {
+            this._previousLeft -=
+                (this.props.thumbTouchSize.width - thumbSize.width) / 2;
+        }
+
         this.props?.onSlidingStart?.(
             this._getRawValues(this.state.values),
             this._activeThumbIndex,
@@ -471,7 +476,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
         if (allMeasured) {
             size.width = Math.max(
                 0,
-                thumbTouchSize?.width || 0 - thumbSize.width,
+                thumbTouchSize?.width || 0 + thumbSize.width,
             );
             size.height = Math.max(
                 0,
@@ -579,10 +584,10 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
         thumbLeft: Animated.AnimatedInterpolation,
         index: number,
     ) => {
-        const {height, y, width} = this._getThumbTouchRect() || {};
+        const {height, x, y, width} = this._getThumbTouchRect() || {};
         const positionStyle = {
             height,
-            left: thumbLeft,
+            left: x,
             top: y,
             width,
         };
@@ -721,7 +726,10 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
             width:
                 interpolatedTrackValues.length === 1
                     ? Animated.add(minTrackWidth, thumbSize.width / 2)
-                    : Animated.add(Animated.multiply(minTrackWidth, -1), maxTrackWidth),
+                    : Animated.add(
+                          Animated.multiply(minTrackWidth, -1),
+                          maxTrackWidth,
+                      ),
             backgroundColor: minimumTrackTintColor,
             ...valueVisibleStyle,
             ...clearBorderRadius,


### PR DESCRIPTION
- https://github.com/miblanchard/react-native-slider/issues/371

I have noticed that the slider's value is not accurate when tapping. The slider jumps to a lower value whenever dragging starts. It is even more incorrect when there is a custom `thumbTouchSize` is used, the problem is even worse.

This happens on web, and also on mobile. Here is an example:

### Before:

https://github.com/miblanchard/react-native-slider/assets/42827/f75d62f6-38f1-41b6-a229-1caab71bbfe3

This PR resolves the issue in my testing. Sliders are now much more accurate:

### After:

https://github.com/miblanchard/react-native-slider/assets/42827/df06e015-f7e6-4c92-bc1c-e1d28869b913

The one thing I'm not 100% happy with is that the dragging will still assume you want to drag the _centre_ of the slider. We should ideally calculate the offset between the starting touch and that position, and maintain that as an offset, so that drags are relative. I may fix that in a follow-up PR if this gets merged.