### PR TITLE
Fix typescript error when passing testID prop

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export type SliderProps = {
     renderMinimumTrackComponent?: () => React.ReactNode;
     renderTrackMarkComponent?: (index: number) => React.ReactNode;
     step?: number;
+    testID?: ViewStyle['testID'];
     thumbImage?: ImageSourcePropType;
     thumbStyle?: ViewStyle;
     thumbTintColor?: string;


### PR DESCRIPTION
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmhmcGo0c2E1bjVmY3BsdXZjam82ejg4eGM2OHVocW11N3VyYnFnaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gw3IWyGkC0rsazTi/giphy.gif)

Adds the `testID` prop to `SliderProp` so typescript doesn't whine about it. Passing the `testID` already successfully works, however TypeScript reports an error because it is not defined in `SliderProps`. 