### PR TITLE
Fix touchable heights causing tall sliders

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -505,7 +505,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
         if (allMeasured) {
             size.width = Math.max(
                 0,
-                thumbTouchSize?.width || 0 + thumbSize.width,
+                (thumbTouchSize?.width || 0) - thumbSize.width,
             );
             size.height = Math.max(
                 0,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -509,7 +509,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
             );
             size.height = Math.max(
                 0,
-                thumbTouchSize?.height || 0 - containerSize.height,
+                (thumbTouchSize?.height || 0) - containerSize.height,
             );
         }
 


### PR DESCRIPTION
Setting `thumbTouchSize` causes the slider's touchable areas to way overstep their bounds becuase of a logic error in the math.

In these examples, the `thumbTouchSize ` is set to 52 – roughly the same size as the track should be. On the latest version of the library, this causes the slider to have a height much greater than it should.

Before:

<img width="425" alt="image" src="https://github.com/user-attachments/assets/87a0aa19-a0e9-48b6-a6ae-6658cfcb36c8">

After:

<img width="417" alt="image" src="https://github.com/user-attachments/assets/90b04cc1-6f5b-4f41-bd90-087f4392f631">
