### PR TITLE
Update thumbTouchSize adjustment for trackClickable={false}

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -285,7 +285,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
             ? nativeEvent.locationX - thumbSize.width
             : this._getThumbLeft(this._getCurrentValue(this._activeThumbIndex));
 
-        if (this.props.thumbTouchSize) {
+        if (this.props.thumbTouchSize && this.props.trackClickable) {
             this._previousLeft -=
                 (this.props.thumbTouchSize.width - thumbSize.width) / 2;
         }


### PR DESCRIPTION
Fixes an issue where if trackClickable is set to false, the adjustments for _previousLeft are not applied correctly and the scrubber jumps slightly if the thumbTouchSize is set.

I fixed this issue originally, but I only just set `trackClickable={false}` today. I noticed that the scrubber was jumping again. I don't know why these two properties would interact like this but I sense it has something to do with the dragging event triggering on the track rather than on the scrubber.

Either way, this fixes the issue very nicely.

Snack: https://snack.expo.dev/@elliottkember/@miblanchard-react-native-slider