### PR TITLE
Feature/styleprop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # DEV
 .vscode
+.idea
 
 # node.js
 #

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import {
     LayoutChangeEvent,
     PanResponder,
     PanResponderInstance,
+    StyleSheet,
     View,
     ViewStyle,
 } from 'react-native';
@@ -865,7 +866,7 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
                                     ? {}
                                     : {
                                           backgroundColor: thumbTintColor,
-                                          ...thumbStyle,
+                                          ...StyleSheet.flatten(thumbStyle),
                                       },
                                 {
                                     transform: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import {Animated, ImageSourcePropType, ViewStyle} from 'react-native';
+import {
+    Animated,
+    ImageSourcePropType,
+    StyleProp,
+    ViewStyle,
+} from 'react-native';
 
 export type Dimensions = {
     height: number;
@@ -21,14 +26,14 @@ export type SliderProps = {
         timing?: Animated.AnimatedProps<ViewStyle>;
     };
     animationType: 'spring' | 'timing';
-    containerStyle?: ViewStyle;
+    containerStyle?: StyleProp<ViewStyle>;
     debugTouchArea?: boolean;
     disabled?: boolean;
     maximumTrackTintColor?: string;
-    maximumTrackStyle?: ViewStyle;
+    maximumTrackStyle?: StyleProp<ViewStyle>;
     maximumValue: number;
     minimumTrackTintColor?: string;
-    minimumTrackStyle?: ViewStyle;
+    minimumTrackStyle?: StyleProp<ViewStyle>;
     minimumValue: number;
     onSlidingComplete?: SliderOnChangeCallback;
     onSlidingStart?: SliderOnChangeCallback;
@@ -50,13 +55,13 @@ export type SliderProps = {
     step?: number;
     testID?: ViewStyle['testID'];
     thumbImage?: ImageSourcePropType;
-    thumbStyle?: ViewStyle;
+    thumbStyle?: StyleProp<ViewStyle>;
     thumbTintColor?: string;
     thumbTouchSize?: Dimensions;
     trackClickable?: boolean;
     trackMarks?: Array<number>;
     trackRightPadding?: number;
-    trackStyle?: ViewStyle;
+    trackStyle?: StyleProp<ViewStyle>;
     value?: Animated.Value | number | Array<number>;
     /**
      * Allows the start from the zero value. The minimum value track can be rendered in two directions from zero.


### PR DESCRIPTION
Replace Slider's `ViewStyle` props with  `StyleProp<ViewStyle>`. 

This way the style props accept not only `ViewStyle` types, but also a (recursive) array of `ViewStyle`, and a `Falsy` type, which translates to `false || null || undefined`.

A user can then pass `containerStyle`, `minimumTrackStyle`, `maximumTrackStyle`, `thumbStyle` and `trackStyle` as:

- array of styles: `style={[styles.style1, styles.style2]}` 
- any `Falsy` value, such as `style={undefined}`

which is not possible with bare `ViewStyle`.

It makes it easier for `Slider` users to optionally pass style overrides in their own `CustomSlider`:

```
const StyledSlider = ({ overrideContainerStyle }: { overrideContainerStyle?: StyleProp<ViewStyle> }) => {
  return (
    <Slider containerStyle={[styles.defaultSliderContainerStyle, overrideContainerStyle]} />
  );
};
```

The API remains backwards compatible with previous versions.
