### PR TITLE
Fix Thumbs overlap,  if you don't set a step value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -404,51 +404,60 @@ export class Slider extends PureComponent<SliderProps, SliderState> {
         );
     };
     _getValue = (gestureState: {dx: number; dy: number}) => {
-        const {containerSize, thumbSize, values} = this.state;
-        const {maximumValue, minimumValue, step, vertical} = this.props;
-        const length = containerSize.width - thumbSize.width;
-        const thumbLeft = vertical
-            ? this._previousLeft + gestureState.dy * -1
-            : this._previousLeft + gestureState.dx;
-        const nonRtlRatio = thumbLeft / length;
-        const ratio = I18nManager.isRTL ? 1 - nonRtlRatio : nonRtlRatio;
-        let minValue = minimumValue;
-        let maxValue = maximumValue;
+      const {containerSize, thumbSize, values} = this.state;
+      const {maximumValue, minimumValue, step, vertical} = this.props;
+      const length = containerSize.width - thumbSize.width;
+      const thumbLeft = vertical
+          ? this._previousLeft + gestureState.dy * -1
+          : this._previousLeft + gestureState.dx;
+      const nonRtlRatio = thumbLeft / length;
+      const ratio = I18nManager.isRTL ? 1 - nonRtlRatio : nonRtlRatio;
+      let minValue = minimumValue;
+      let maxValue = maximumValue;
+      const rawValues = this._getRawValues(values);
 
-        const rawValues = this._getRawValues(values);
+      let buffer;
+      if (step) {
+          buffer = step;
+      } else {
+          const trackLength = containerSize.width - thumbSize.width;
+          const minPixelDistance = thumbSize.width;
+          buffer =
+              trackLength > 0
+                  ? (minPixelDistance / trackLength) *
+                    (maximumValue - minimumValue)
+                  : 0;
+      }
 
-        const buffer = step ? step : 0.1;
+      if (values.length === 2) {
+          if (this._activeThumbIndex === 1) {
+              minValue = rawValues[0] + buffer;
+          } else {
+              maxValue = rawValues[1] - buffer;
+          }
+      }
 
-        if (values.length === 2) {
-            if (this._activeThumbIndex === 1) {
-                minValue = rawValues[0] + buffer;
-            } else {
-                maxValue = rawValues[1] - buffer;
-            }
-        }
-
-        if (step) {
-            return Math.max(
-                minValue,
-                Math.min(
-                    maxValue,
-                    minimumValue +
-                        Math.round(
-                            (ratio * (maximumValue - minimumValue)) / step,
-                        ) *
-                            step,
-                ),
-            );
-        }
-
-        return Math.max(
-            minValue,
-            Math.min(
-                maxValue,
-                ratio * (maximumValue - minimumValue) + minimumValue,
-            ),
-        );
-    };
+      if (step) {
+          return Math.max(
+              minValue,
+              Math.min(
+                  maxValue,
+                  minimumValue +
+                      Math.round(
+                          (ratio * (maximumValue - minimumValue)) / step,
+                      ) *
+                          step,
+              ),
+          );
+      }
+      return Math.max(
+          minValue,
+          Math.min(
+              maxValue,
+              ratio * (maximumValue - minimumValue) + minimumValue,
+          ),
+      );
+  };
     _getCurrentValue = (thumbIndex: number = 0) =>
         this.state.values[thumbIndex].__getValue();
 


### PR DESCRIPTION
#### If you do not set the step strictly, then an overlapping effect occurs
![image](https://github.com/user-attachments/assets/1eb32ca9-911a-458d-9d87-ac2005440e64)
#### With step (size 3) - okay (i cant do gesture more)
![image](https://github.com/user-attachments/assets/8a9d69c8-2199-4d0e-90e6-838085c06c6d)
#### After my commit changes (thumbs not overlap)
![image](https://github.com/user-attachments/assets/05ca30ff-eaae-414e-882c-ebe453e31527)

